### PR TITLE
Added new property "-duplicates" to repo_list command

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -129,6 +129,12 @@
                     Reverses the order of all urls in the repository list.
                 </documentation>
             </arg>
+
+            <arg name="-duplicates" type="void">
+                <documentation>
+                    List the duplicated repository keys.
+                </documentation>
+            </arg>
         </args>
 
     </command>

--- a/duell.py.generalArguments
+++ b/duell.py.generalArguments
@@ -129,6 +129,12 @@
                     Reverses the order of all urls in the repository list.
                 </documentation>
             </arg>
+
+            <arg name="-duplicates" type="void">
+                <documentation>
+                    List the duplicated repository keys.
+                </documentation>
+            </arg>
         </args>
 
     </command>

--- a/duell/commands/RepoConfigCommand.hx
+++ b/duell/commands/RepoConfigCommand.hx
@@ -30,6 +30,7 @@ import duell.objects.Arguments;
 import duell.helpers.LogHelper;
 import duell.helpers.DuellConfigHelper;
 import duell.objects.DuellConfigJSON;
+import duell.helpers.DuellLibListHelper;
 
 import haxe.CallStack;
 
@@ -134,6 +135,17 @@ class RepoConfigCommand implements IGDCommand
 			duellConfig.repoListURLs.reverse();
 			duellConfig.writeToConfig();
 			LogHelper.info("Reversed all entries");
+		} 
+		else if (Arguments.isSet("-duplicates"))
+		{
+			LogHelper.info("\n");
+			LogHelper.info("\x1b[2m------");
+
+			printDuplicates();
+			
+			LogHelper.info("");
+			LogHelper.info("------\x1b[0m");
+			LogHelper.info("\n");
 		}
 
 		LogHelper.info("\n");
@@ -153,6 +165,15 @@ class RepoConfigCommand implements IGDCommand
 		{
 			LogHelper.info(counter + ". " + repo);
 			counter++;
+		}
+	}
+
+	private function printDuplicates()
+	{
+		var list = DuellLibListHelper.getDuplicatesFromRepoLists();
+		for (repo in list.keys())
+		{
+			LogHelper.info("Duplicated key: " + repo);
 		}
 	}
 }


### PR DESCRIPTION
- implemented new argument "-duplicates" for "repo_list" command
- extended documentation of repo_list command
- changed console output when repo-urls are created and duplicates are existing
- added new function to retrieve duplicated repo-urls
