### PR TITLE
bugfix:  wrong path-output for haxe-libraries with dependencies

### DIFF
--- a/duell.py
+++ b/duell.py
@@ -4425,8 +4425,8 @@ class duell_helpers_Template:
 			while (_g_head is not None):
 				e3 = None
 				def _hx_local_0():
-					nonlocal _g_head
 					nonlocal _g_val
+					nonlocal _g_head
 					_g_val = (_g_head[0] if 0 < len(_g_head) else None)
 					_g_head = (_g_head[1] if 1 < len(_g_head) else None)
 					return _g_val
@@ -4476,8 +4476,8 @@ class duell_helpers_Template:
 			while (_g_head1 is not None):
 				p = None
 				def _hx_local_3():
-					nonlocal _g_val1
 					nonlocal _g_head1
+					nonlocal _g_val1
 					_g_val1 = (_g_head1[0] if 0 < len(_g_head1) else None)
 					_g_head1 = (_g_head1[1] if 1 < len(_g_head1) else None)
 					return _g_val1
@@ -5772,7 +5772,7 @@ _hx_classes["duell.objects.HXCPPConfigXML"] = duell_objects_HXCPPConfigXML
 class duell_objects_Haxelib:
 	_hx_class_name = "duell.objects.Haxelib"
 	_hx_fields = ["name", "version", "path"]
-	_hx_methods = ["setPath", "exists", "isHaxelibInstalled", "getPath", "getHaxelibPathOutput", "selectVersion", "uninstall", "install", "isGitVersion", "toString"]
+	_hx_methods = ["setPath", "exists", "isHaxelibInstalled", "getPath", "isValidLibPath", "getHaxelibPathOutput", "selectVersion", "uninstall", "install", "isGitVersion", "toString"]
 	_hx_statics = ["haxelibCache", "getHaxelib", "solveConflict"]
 
 	def __init__(self,name,version = ""):
@@ -5831,7 +5831,10 @@ class duell_objects_Haxelib:
 			i = _g1
 			_g1 = (_g1 + 1)
 			if StringTools.startsWith(StringTools.trim((lines[i] if i >= 0 and i < len(lines) else None)),"-D"):
-				self.path = StringTools.trim(python_internal_ArrayImpl._get(lines, (i - 1)))
+				pathLine = python_internal_ArrayImpl._get(lines, (i - 1))
+				StringTools.trim(pathLine)
+				if self.isValidLibPath(pathLine,self.name):
+					self.path = pathLine
 		if (self.path == ""):
 			try:
 				_g2 = 0
@@ -5839,13 +5842,16 @@ class duell_objects_Haxelib:
 					line = (lines[_g2] if _g2 >= 0 and _g2 < len(lines) else None)
 					_g2 = (_g2 + 1)
 					if ((line != "") and ((HxString.substr(line,0,1) != "-"))):
-						if sys_FileSystem.exists(line):
+						if self.isValidLibPath(line,self.name):
 							self.path = line
 							break
 			except Exception as _hx_e:
 				_hx_e1 = _hx_e.val if isinstance(_hx_e, _HxException) else _hx_e
 				pass
 		return self.path
+
+	def isValidLibPath(self,path,libName):
+		return (sys_FileSystem.exists(path) and ((path.find(libName) != -1)))
 
 	def getHaxelibPathOutput(self):
 		nameToTry = self.name

--- a/duell/objects/Haxelib.hx
+++ b/duell/objects/Haxelib.hx
@@ -144,7 +144,13 @@ class Haxelib
 
 			if (lines[i].trim().startsWith('-D'))
 			{
-				path = lines[i - 1].trim();
+				var pathLine = lines[i - 1];
+				pathLine.trim();
+
+				if (isValidLibPath(pathLine, name))
+				{
+					path = pathLine;
+				}
 			}
 
 		}
@@ -156,7 +162,7 @@ class Haxelib
 				{
 					if (line != "" && line.substr(0, 1) != "-")
 					{
-						if (FileSystem.exists(line))
+						if (isValidLibPath(line, name))
 						{
 							path = line;
 							break;
@@ -168,6 +174,12 @@ class Haxelib
 		}
 
 		return path;
+	}
+
+	private function isValidLibPath(path:String, libName:String):Bool
+	{
+		// check if path exists and path contains libName
+		return FileSystem.exists(path) && path.indexOf(libName) != -1;
 	}
 
 	private function getHaxelibPathOutput(): String


### PR DESCRIPTION
The bugfix checks if detected path contains the name of the library. It makes sure that you don't get the dependency paths. 
