### PR TITLE
Fixed ls command for showing the full time on linux

### DIFF
--- a/duell/helpers/DirHashHelper.hx
+++ b/duell/helpers/DirHashHelper.hx
@@ -55,6 +55,16 @@ class DirHashHelper
 				errorMessage: "hashing folder structure"
 			});
 		}
+		else if (PlatformHelper.hostPlatform == Platform.LINUX)
+		{
+			process = new DuellProcess(null, "ls", ["-onp", "--time-style=full-iso", path],
+			{
+				systemCommand : true,
+				block : true,
+				shutdownOnError : true,
+				errorMessage: "hashing folder structure"
+			});
+		}
 		else
 		{
 			process = new DuellProcess(null, "ls", ["-onpT", path],


### PR DESCRIPTION
I tempered around with our duell tool with Ubuntu and found out that the ls command behaves differently between Mac and Linux(Ubuntu). On Ubuntu the T parameter is for aligning the tabs, but on Mac its for showing the time. Fixed it so that the file hashes are produced correctly. Greetz.
Would be nice to have this tagged soon as I need it for demonstration purpose.
