### PR TITLE
Support for download with authentication and fix update with -logFile

### DIFF
--- a/duell/commands/UpdateCommand.hx
+++ b/duell/commands/UpdateCommand.hx
@@ -120,6 +120,7 @@ class UpdateCommand implements IGDCommand
         if(Arguments.isSet('-logFile'))
         {
         	useVersionFileToRecreateSpecificVersions();
+			saveUpdateExecution();
         	return 'success';
         }
         

--- a/duell/helpers/DownloadHelper.hx
+++ b/duell/helpers/DownloadHelper.hx
@@ -34,6 +34,9 @@ import haxe.io.Path;
 import haxe.Http;
 
 import python.urllib.Request;
+import python.urllib.HTTPPasswordMgrWithDefaultRealm;
+import python.urllib.HTTPBasicAuthHandler;
+import python.urllib.OpenerDirector;
 
 class DownloadHelper
 {
@@ -63,5 +66,15 @@ class DownloadHelper
 			var current = blocknr*blocksize;
 			Sys.print(Std.string(current)+"/"+Std.string(size)+" ("+Std.int((current*100.0)/size)+"%)\r");
 		});
+	}
+
+	public static function setUsernameAndPassword(toplevelURL: String, username: String, password: String): Void
+	{
+		var password_mgr = new HTTPPasswordMgrWithDefaultRealm();
+		password_mgr.add_password(null, toplevelURL, username, password);
+		var handler = new HTTPBasicAuthHandler(password_mgr);
+		var opener: OpenerDirector = Request.build_opener(handler);
+		opener.open(toplevelURL);
+		Request.install_opener(opener);
 	}
 }

--- a/python/urllib/HTTPBasicAuthHandler.hx
+++ b/python/urllib/HTTPBasicAuthHandler.hx
@@ -1,0 +1,7 @@
+package python.urllib;
+
+@:pythonImport("urllib.request", "HTTPBasicAuthHandler")
+extern class HTTPBasicAuthHandler
+{
+	public function new(manager: HTTPPasswordMgrWithDefaultRealm);
+}

--- a/python/urllib/HTTPPasswordMgrWithDefaultRealm.hx
+++ b/python/urllib/HTTPPasswordMgrWithDefaultRealm.hx
@@ -1,0 +1,8 @@
+package python.urllib;
+
+@:pythonImport("urllib.request", "HTTPPasswordMgrWithDefaultRealm")
+extern class HTTPPasswordMgrWithDefaultRealm
+{
+	public function new();
+	public function add_password(realm: Dynamic, topLevelURL: String, usernam: String, password: String): Void;
+}

--- a/python/urllib/OpenerDirector.hx
+++ b/python/urllib/OpenerDirector.hx
@@ -1,0 +1,7 @@
+package python.urllib;
+
+@:pythonImport("urllib.request", "OpenerDirector")
+extern class OpenerDirector
+{
+	public function open(url: String): Void;
+}

--- a/python/urllib/Request.hx
+++ b/python/urllib/Request.hx
@@ -27,6 +27,8 @@
 package python.urllib;
 
 import python.KwArgs;
+import python.urllib.HTTPBasicAuthHandler;
+import python.urllib.OpenerDirector;
 
 typedef URLOpenArgs =
 {
@@ -38,4 +40,6 @@ extern class Request
 {
     public static function urlopen(url: String, ?kwArgs: KwArgs<URLOpenArgs>): Void;
     public static function urlretrieve(url: String, ?filename: String, ?progress: Dynamic) : Void;
+	public static function build_opener(handler: HTTPBasicAuthHandler): OpenerDirector;
+	public static function install_opener(opener: OpenerDirector): Void;
 }


### PR DESCRIPTION
Added a possibility to download from services that require authentication.
Saving update execution after an update with -logFile to prevent "You have not run an update for this project recently. Would like to do so? [y/n]?" message after an update with -logFile.
