### PR TITLE
Haxelib Git versions refactor

### DIFF
--- a/duell.py
+++ b/duell.py
@@ -4869,8 +4869,8 @@ class duell_helpers_Template:
 			while (_g_head1 is not None):
 				p = None
 				def _hx_local_3():
-					nonlocal _g_val1
 					nonlocal _g_head1
+					nonlocal _g_val1
 					_g_val1 = (_g_head1[0] if 0 < len(_g_head1) else None)
 					_g_head1 = (_g_head1[1] if 1 < len(_g_head1) else None)
 					return _g_val1
@@ -6265,6 +6265,8 @@ class duell_objects_Haxelib:
 		if self.isHaxelibInstalled():
 			if (self.version == ""):
 				return True
+			if self.isGitVersion():
+				return True
 			haxelibListOutput = self.getHaxelibListOutput()
 			haxelibListOutputSplit = haxelibListOutput.split("\n")
 			haxelibLine = None
@@ -6277,23 +6279,15 @@ class duell_objects_Haxelib:
 			if (haxelibLine is None):
 				raise _HxException((("Incorrect haxelib list state, couldn't find lib " + HxOverrides.stringOrNull(self.name)) + "."))
 			splitLine = haxelibLine.split(" ")
-			if self.isGitVersion():
-				_g1 = 0
-				while (_g1 < len(splitLine)):
-					element = (splitLine[_g1] if _g1 >= 0 and _g1 < len(splitLine) else None)
-					_g1 = (_g1 + 1)
-					if (element.find("dev") != -1):
-						return True
-			else:
-				_g2 = 0
-				while (_g2 < len(splitLine)):
-					element1 = (splitLine[_g2] if _g2 >= 0 and _g2 < len(splitLine) else None)
-					_g2 = (_g2 + 1)
-					def _hx_local_3():
-						_hx_str = self.version
-						return element1.find(_hx_str)
-					if (_hx_local_3() != -1):
-						return True
+			_g1 = 0
+			while (_g1 < len(splitLine)):
+				element = (splitLine[_g1] if _g1 >= 0 and _g1 < len(splitLine) else None)
+				_g1 = (_g1 + 1)
+				def _hx_local_2():
+					_hx_str = self.version
+					return element.find(_hx_str)
+				if (_hx_local_2() != -1):
+					return True
 		return False
 
 	def isHaxelibInstalled(self):

--- a/duell/helpers/GitHelper.hx
+++ b/duell/helpers/GitHelper.hx
@@ -72,17 +72,22 @@ class GitHelper
         return gitProcess.exitCode();
     }
 
-    static public function pull(destination : String) : Int
+    static public function pull(destination : String, parameters: Array<String> = null) : Int
     {
         if (!ConnectionHelper.isOnline())
         {
             return 0;
         }
 
+		if (parameters == null)
+		{
+			parameters = [];
+		}
+
         var gitProcess = new DuellProcess(
                                         destination,
                                         "git",
-                                        ["pull"],
+                                        ["pull"].concat(parameters),
                                         {
                                             systemCommand : true,
                                             loggingPrefix : "[Git]",

--- a/duell/objects/Haxelib.hx
+++ b/duell/objects/Haxelib.hx
@@ -90,6 +90,8 @@ class Haxelib
 		{
 			if (version == "") return true;
 
+			if (isGitVersion()) return true;
+
 			var haxelibListOutput = getHaxelibListOutput();
 
 			var haxelibListOutputSplit = haxelibListOutput.split("\n");
@@ -109,24 +111,11 @@ class Haxelib
 
 			var splitLine = haxelibLine.split(" ");
 
-			if (isGitVersion())
+			for (element in splitLine)
 			{
-				for (element in splitLine)
+				if (element.indexOf(version) != -1)
 				{
-					if (element.indexOf("dev") != -1)
-					{
-						return true;
-					}
-				}
-			}
-			else
-			{
-				for (element in splitLine)
-				{
-					if (element.indexOf(version) != -1)
-					{
-						return true;
-					}
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
Haxelib versions that are set to git are a bit too simplistic. Because of that we now manage them in the duell tool. So they are saved in duell lib folder as haxelib_<name_of_lib>. Setting the correct branch and pulling is also managed by the duell tool.

This requires fixes on the build plugins as well. If all repos are merged at the same time, it shouldn't require a major.
